### PR TITLE
WIP: :rocket: Add RewardsFlywheel to ManagedPortfolio

### DIFF
--- a/contracts/ragnarok/ManagedPortfolio.sol
+++ b/contracts/ragnarok/ManagedPortfolio.sol
@@ -10,8 +10,9 @@ import {IBulletLoans, BulletLoanStatus} from "./interfaces/IBulletLoans.sol";
 import {IProtocolConfig} from "./interfaces/IProtocolConfig.sol";
 import {ILenderVerifier} from "./interfaces/ILenderVerifier.sol";
 import {InitializableManageable} from "./access/InitializableManageable.sol";
+import {RewardsFlywheel} from "./rewards/RewardsFlywheel.sol";
 
-contract ManagedPortfolio is ERC20Upgradeable, InitializableManageable, IERC721Receiver, IManagedPortfolio {
+contract ManagedPortfolio is ERC20Upgradeable, InitializableManageable, IERC721Receiver, IManagedPortfolio, RewardsFlywheel {
     using SafeERC20 for IERC20WithDecimals;
 
     uint256 internal constant YEAR = 365 days;
@@ -80,6 +81,12 @@ contract ManagedPortfolio is ERC20Upgradeable, InitializableManageable, IERC721R
         endDate = block.timestamp + _duration;
         maxSize = _maxSize;
         managerFee = _managerFee;
+    }
+
+    function setDepositRewards(address tokenAddress, address treasuryAddress, uint256 rewardsRate) external onlyManager {
+        setRewardsToken(tokenAddress);
+        setRewardsTreasury(treasuryAddress);
+        setRewardsRate(rewardsRate);
     }
 
     function deposit(uint256 depositAmount, bytes memory metadata) external onlyOpened {
@@ -247,12 +254,28 @@ contract ManagedPortfolio is ERC20Upgradeable, InitializableManageable, IERC721R
         }
     }
 
+    function totalRewardShares() internal view virtual override returns (uint256) {
+        return totalSupply();
+    }
+
+    function rewardSharesFor(address account) internal view virtual override returns (uint256) {
+        return balanceOf(account);
+    }
+
     function _beforeTokenTransfer(
         address from,
         address to,
         uint256
     ) internal virtual override {
         require(from == address(0) || to == address(0), "ManagedPortfolio: transfer of LP tokens prohibited");
+
+        updateRewardsFlywheel();
+
+        if (from != address(0))
+            distributeRewardsFor(from);
+
+        if (to != address(0))
+            distributeRewardsFor(to);
     }
 
     function onERC721Received(

--- a/contracts/ragnarok/ManagedPortfolio.sol
+++ b/contracts/ragnarok/ManagedPortfolio.sol
@@ -74,6 +74,7 @@ contract ManagedPortfolio is ERC20Upgradeable, InitializableManageable, IERC721R
     ) external initializer {
         InitializableManageable.initialize(_manager);
         ERC20Upgradeable.__ERC20_init(_name, _symbol);
+        initializeRewards();
         underlyingToken = _underlyingToken;
         bulletLoans = _bulletLoans;
         protocolConfig = _protocolConfig;

--- a/contracts/ragnarok/rewards/RewardsFlywheel.sol
+++ b/contracts/ragnarok/rewards/RewardsFlywheel.sol
@@ -69,6 +69,14 @@ abstract contract RewardsFlywheel {
         }
     }
 
+    function initializeRewards() internal {
+        if (rewardsState.index == 0) {
+            // Rewards state uninitialized, so we initialize it
+            rewardsState.index = 1;
+            rewardsState.block = block.number.toUint32();
+        }
+    }
+
     function setRewardsToken(address token) internal {
         if (token != rewardsToken) {
             rewardsToken = token;
@@ -95,13 +103,6 @@ abstract contract RewardsFlywheel {
             // Update rewards rate and emit event
             rewardsRatePerBlock = rewardsRate;
             emit RewardsRateChanged(rewardsRate);
-
-            if (rewardsState.index == 0) {
-                // This is when we initialize rewards... if users enter the rewards flywheel in this block, they'll
-                // miss out on rewards until distributeRewardsFor is called for them since they'll have a rewards
-                // index of 0, which is considered uninitialized. By setting to 1 here, we avoid this scenario.
-                rewardsState.index == 1;
-            }
         }
     }
 

--- a/contracts/ragnarok/rewards/RewardsFlywheel.sol
+++ b/contracts/ragnarok/rewards/RewardsFlywheel.sol
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+abstract contract RewardsFlywheel {
+    using SafeCast for uint256;
+    using SafeERC20 for IERC20;
+
+    struct RewardsState {
+        uint224 index;
+        uint32 block;
+    }
+
+    uint256 private constant REWARDS_PRECISION_SCALAR = 1e36;
+
+    uint256 public rewardsRatePerBlock;
+
+    RewardsState public rewardsState;
+
+    address public rewardsToken;
+    address public rewardsTreasury;
+
+    mapping(address => uint256) public accountRewardsIndex;
+    mapping(address => uint256) public accountRewardsAccruement;
+
+    event DistributedRewards(address indexed account, uint256 amount);
+    event ClaimedRewards(address indexed account, uint256 amount);
+
+    event RewardsRateChanged(uint256 rewardsRatePerBlock);
+    event RewardsTokenChanged(address token);
+    event RewardsTreasuryChanged(address treasuryAddress);
+
+    function claimRewards() external {
+        RewardsFlywheel(this).claimRewardsFor(msg.sender);
+    }
+
+    function claimRewardsFor(address account) external {
+        address[] memory accounts = new address[](1);
+        accounts[0] = account;
+
+        RewardsFlywheel(this).claimRewardsFor(accounts);
+    }
+
+    function claimRewardsFor(address[] calldata accounts) external {
+        // Update the flywheel
+        updateRewardsFlywheel();
+        
+        // Distribute rewards for all accounts
+        for (uint256 i = 0; i < accounts.length; ++i)
+            distributeRewardsFor(accounts[i]);
+
+        // Claim rewards for all accounts
+        for (uint256 i = 0; i < accounts.length; ++i) {
+            // Get the amount of rewards accrued for the account
+            uint256 accrued = accountRewardsAccruement[accounts[i]];
+
+            // Set the amount of rewards accrued for the account to 0 to prevent re-entrancy attacks
+            accountRewardsAccruement[accounts[i]] = 0;
+
+            uint256 claimed = processRewardsClaim(accounts[i], accrued);
+
+            if (claimed < accrued) {
+                // We didn't have enough to transfer all accrued rewards for the account, so we store the difference
+                accountRewardsAccruement[accounts[i]] = accrued - claimed;
+            }
+        }
+    }
+
+    function setRewardsToken(address token) internal {
+        if (token != rewardsToken) {
+            rewardsToken = token;
+
+            emit RewardsTokenChanged(token);
+        }
+    }
+
+    function setRewardsTreasury(address treasuryAddress) internal {
+        if (treasuryAddress != rewardsTreasury) {
+            rewardsTreasury = treasuryAddress;
+
+            emit RewardsTreasuryChanged(treasuryAddress);
+        }
+    }
+
+    function setRewardsRate(uint256 rewardsRate) internal {
+        if (rewardsRate != rewardsRatePerBlock) {
+            // Reward rate updated so let's update the flywheel to ensure that
+            //  1. Rewards accrued properly for the old rate, and
+            //  2. Rewards accrued at the new rate starts after this block.
+            updateRewardsFlywheel();
+
+            // Update rewards rate and emit event
+            rewardsRatePerBlock = rewardsRate;
+            emit RewardsRateChanged(rewardsRate);
+
+            if (rewardsState.index == 0) {
+                // This is when we initialize rewards... if users enter the rewards flywheel in this block, they'll
+                // miss out on rewards until distributeRewardsFor is called for them since they'll have a rewards
+                // index of 0, which is considered uninitialized. By setting to 1 here, we avoid this scenario.
+                rewardsState.index == 1;
+            }
+        }
+    }
+
+    function updateRewardsFlywheel() internal {
+        RewardsState storage state = rewardsState;
+        uint256 rewardsRate = rewardsRatePerBlock;
+
+        // Calculate change in blocks since last update
+        uint256 deltaBlocks = block.number - state.block;
+
+        if (deltaBlocks > 0 && rewardsRate > 0) {
+            // Rewards are being distributed, so update
+            uint256 tShares = totalRewardShares();
+            if (tShares > 0) {
+                uint256 rewardsAccrued = deltaBlocks * rewardsRate;
+
+                uint256 accruedPerShare = (rewardsAccrued * REWARDS_PRECISION_SCALAR) / tShares;
+
+                state.index = (state.index + accruedPerShare).toUint224();
+                state.block = block.number.toUint32();
+            } else
+                state.block = block.number.toUint32();
+        } else if (deltaBlocks > 0) {
+            // Record block number of latest update
+            state.block = block.number.toUint32();
+        }
+    }
+
+    function distributeRewardsFor(address account) internal {
+        RewardsState storage state = rewardsState;
+
+        uint256 stateIndex = state.index;
+        uint256 accIndex = accountRewardsIndex[account];
+
+        // Update account's index to the current index since we are distributing accrued rewards
+        accountRewardsIndex[account] = stateIndex;
+
+        if (accIndex == 0) {
+            // No rewards accrued
+            return;
+        }
+
+        // Calculate change in the cumulative sum of the rewards per share accrued
+        uint256 accruedPerShare = stateIndex - accIndex;
+        if (accruedPerShare > 0) {
+            uint256 accountShares = rewardSharesFor(account);
+
+            if (accountShares > 0) {
+                // Calculate rewards accrued for the account
+                uint256 rewardsAccrued = (accountShares * accruedPerShare) / REWARDS_PRECISION_SCALAR;
+
+                // Add the accruement for the account
+                accountRewardsAccruement[account] += rewardsAccrued;
+
+                emit DistributedRewards(account, rewardsAccrued);
+            }
+        }
+    }
+
+    function totalRewardShares() internal view virtual returns (uint256);
+
+    function rewardSharesFor(address account) internal view virtual returns (uint256);
+
+    function processRewardsClaim(address account, uint256 amount) private returns(uint256) {
+        // Don't do anything if we're trying to claim nothing
+        if (amount == 0)
+            return 0;
+
+        address from = rewardsTreasury;
+        if (from == address(0)) {
+            // Zero address is an alias for this contract's address
+            from = address(this);
+        }
+
+        IERC20 token = IERC20(rewardsToken);
+        uint256 amountRemaining = token.balanceOf(from);
+        
+        // If the amount to be claimed is more than the remaining, we try to claim what's left
+        if (amount > amountRemaining)
+            amount = amountRemaining;
+
+        if (amount > 0) {
+            // We have tokens to send, so transfer them
+            token.safeTransferFrom(from, account, amount);
+
+            // Note: We could verify that the treasury's balance change matches the amount, but we don't for gas
+            // savings. We assume the rewards token doesn't do anything weird with transfers.
+
+            emit ClaimedRewards(account, amount);
+        }
+
+        return amount;
+    }
+
+    uint256[45] private __gap;
+}


### PR DESCRIPTION
Allow rewards to be distributed to depositors on-the-fly.

The ideal setup for this is to create a rewards treasury that holds TRU, have this treasury increase the allowance for whichever portfolio that'll have rewards, then for the manager of the portfolio to call `setDepositRewards(TRU_ADDRESS, TREASURY_ADDRESS, REWARDS_RATE)` where _REWARDS_RATE_ equals the number of TRU (in wei) to be distributed per block to depositors.

Depositors can then call `claimRewards()` at any time to collect their accrued TRU rewards.

Requesting comments before test cases are written. Specific questions:
- Should the rewards token be changeable after it's first set?

:rocket: 